### PR TITLE
updated to laminas-form v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ laminas-mvc-form is a Composer metapackage that provides a single package for
 installing all packages necessary to fully use [laminas-form](https://docs.laminas.dev/laminas-form)
 under [laminas-mvc](https://docs.laminas.dev/laminas-mvc), including:
 
-- [laminas/laminas-code](https://docs.laminas.dev/laminas-code/)
+- [doctrine/annotations](https://www.doctrine-project.org/projects/annotations.html)
 - [laminas/laminas-form](https://docs.laminas.dev/laminas-form/)
 - [laminas/laminas-i18n](https://docs.laminas.dev/laminas-i18n/)
 

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,8 @@
         }
     },
     "require": {
-        "laminas/laminas-code": "^3.5.1",
-        "laminas/laminas-form": "^2.17.0",
-        "laminas/laminas-i18n": "^2.11.1"
-    },
-    "replace": {
-        "zendframework/zend-mvc-form": "^1.0.0"
+        "doctrine/annotations": "^1.13.2",
+        "laminas/laminas-form": "^3.0.1",
+        "laminas/laminas-i18n": "^2.11.2"
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This PR updates laminas-form from v2 to v3. To keep the functionality of this package, doctrine/annotations has been added to the dependencies, while laminas-code has been removed. This allows annotation parsing with laminas-form v3, as laminas-code did with v2.

From my point of view this should be considered a BC break, as laminas-form v3 introduced typed parameters and return values. Furthermore, the switch from laminas-code to doctrine/annotations may - at least at some lower level, i.e. when users add custom annotations - bring some BC breaks as well.

Therefore, this should go in a 2.0.x, though that branch does not exist yet, hence the target of 1.3.x currently.